### PR TITLE
Adding underscore(_) to the regex, as when any version contains underscore in the database we're skipping this CVE for the resource.

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -21,7 +21,7 @@ const (
 	// The raw regular expression string used for testing the validity of a version.
 	regex = `v?([0-9]+(\.[0-9]+)*)` +
 		`(-([0-9]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)|(-?([A-Za-z\-~]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)))?` +
-		`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?`
+		`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~_]+)*))?`
 )
 
 // Version represents a single version.


### PR DESCRIPTION
In aqua-db we've versions like 1.8.0_371 so for these even there are other vulnerable versions while comparing whether it is vulnerable or we're failing and skipping the CVE.